### PR TITLE
Implement basic RVQ pipeline and dataset utilities

### DIFF
--- a/signstream/configs/default.yaml
+++ b/signstream/configs/default.yaml
@@ -11,12 +11,14 @@ data:
     dropout_prob: 0.05
 
 model:
+  arch: mlp
   latent_dim: 256
   type_embed_dim: 16
   rvq:
     levels: 2
     codebook_size: 128
     commitment_beta: 0.25
+    usage_beta: 0.0
 
 train:
   epochs: 1
@@ -25,6 +27,7 @@ train:
   wd: 0.0
   device: cpu
   seed: 42
+  temporal_alpha: 0.0
 
 export:
   enable_rle: true

--- a/signstream/data/datasets.py
+++ b/signstream/data/datasets.py
@@ -220,6 +220,7 @@ class CSLDailyDataset(Dataset):
 
         # Use the larger dimension as unit length
         unit_length = torch.max(bbox_width, bbox_height).clamp(min=1e-6)
+        unit_length = unit_length.view(1, -1, 1)
 
         # Normalize positions (keep confidence scores unchanged)
         poses_normalized = poses.clone()

--- a/signstream/inference/export_tokens.py
+++ b/signstream/inference/export_tokens.py
@@ -1,0 +1,94 @@
+import argparse
+import json
+import yaml
+import torch
+from typing import List
+
+from signstream.data.datasets import CSLDailyDataset
+from signstream.models.rvq.rvq_model import RVQModel
+from .rle import rle_encode
+
+
+def load_model(config: dict, checkpoint: str | None = None) -> RVQModel:
+    part = "full_body"
+    # Full body contains 133 keypoints (COCO WholeBody without global).
+    num_points = 133
+    input_dim = config["data"]["chunk_len"] * num_points * 3
+
+    model = RVQModel(
+        input_dim=input_dim,
+        latent_dim=config["model"]["latent_dim"],
+        codebook_size=config["model"]["rvq"]["codebook_size"],
+        levels=config["model"]["rvq"]["levels"],
+        commitment_beta=config["model"]["rvq"].get("commitment_beta", 0.25),
+    )
+    if checkpoint:
+        state = torch.load(checkpoint, map_location="cpu")
+        model.load_state_dict(state["model_state"])
+    model.eval()
+    return model
+
+
+def export_samples(
+    model: RVQModel,
+    dataset: CSLDailyDataset,
+    num_samples: int,
+    enable_rle: bool = False,
+) -> List[dict]:
+    device = next(model.parameters()).device
+    results = []
+    part = "full_body"
+    for i in range(num_samples):
+        sample = dataset[i]
+        x = sample["chunks"][part]  # [N, L, K, 3]
+        N, L, K, C = x.shape
+        x_flat = x.view(N, L * K * C).to(device)
+        with torch.no_grad():
+            _, codes, _ = model(x_flat, part)
+        codes_list = codes.cpu().tolist()
+        tokens = [{"t": t, "FB": c} for t, c in enumerate(codes_list)]
+        if enable_rle:
+            fb_tokens = [tok["FB"] for tok in tokens]
+            compressed = rle_encode(fb_tokens)
+            tokens = [{"t": t, "FB": c} for t, c in enumerate(compressed)]
+        results.append(
+            {
+                "video_name": sample["name"],
+                "fps": dataset.fps,
+                "chunk_len": dataset.chunk_len,
+                "tokens": tokens,
+                "rle": enable_rle,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export RVQ tokens")
+    parser.add_argument("--config", type=str, default="configs/default.yaml")
+    parser.add_argument("--checkpoint", type=str, default=None)
+    parser.add_argument("--split", type=str, default="val")
+    parser.add_argument("--num-samples", type=int, default=1)
+    parser.add_argument("--out", type=str, default="tokens.jsonl")
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    dataset = CSLDailyDataset(
+        root_dir=config["data"]["root"],
+        split=args.split,
+        chunk_len=config["data"]["chunk_len"],
+        fps=config["data"]["fps"],
+    )
+    model = load_model(config, args.checkpoint)
+    samples = export_samples(
+        model, dataset, args.num_samples, enable_rle=config["export"]["enable_rle"]
+    )
+    with open(args.out, "w", encoding="utf-8") as f:
+        for s in samples:
+            f.write(json.dumps(s) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/signstream/inference/rle.py
+++ b/signstream/inference/rle.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def rle_encode(tokens: List[List[int]]) -> List:
+    """Run-length encode a sequence of token lists."""
+    if not tokens:
+        return []
+    encoded: List = []
+    prev = tokens[0]
+    count = 1
+    for curr in tokens[1:]:
+        if curr == prev:
+            count += 1
+        else:
+            if count > 1:
+                encoded.append(["NC", count])
+            else:
+                encoded.append(prev)
+            prev = curr
+            count = 1
+    if count > 1:
+        encoded.append(["NC", count])
+    else:
+        encoded.append(prev)
+    return encoded

--- a/signstream/models/metrics/recon.py
+++ b/signstream/models/metrics/recon.py
@@ -8,3 +8,8 @@ import torch.nn.functional as F
 def mse_loss(pred: Tensor, target: Tensor) -> Tensor:
     """Compute mean squared error loss."""
     return F.mse_loss(pred, target)
+
+
+def huber_loss(pred: Tensor, target: Tensor, delta: float = 1.0) -> Tensor:
+    """Huber (smooth L1) loss."""
+    return F.smooth_l1_loss(pred, target, beta=delta)

--- a/signstream/models/metrics/recon.py
+++ b/signstream/models/metrics/recon.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+import torch.nn.functional as F
+
+
+def mse_loss(pred: Tensor, target: Tensor) -> Tensor:
+    """Compute mean squared error loss."""
+    return F.mse_loss(pred, target)

--- a/signstream/models/metrics/temporal.py
+++ b/signstream/models/metrics/temporal.py
@@ -1,0 +1,15 @@
+import torch
+from torch import Tensor
+
+
+def temporal_loss(latents: Tensor) -> Tensor:
+    """Penalize differences between consecutive latent vectors.
+
+    Args:
+        latents: Tensor of shape ``[B, N, D]`` representing quantized latents
+            per chunk.
+    Returns:
+        Scalar temporal smoothness loss.
+    """
+    diff = latents[:, 1:, :] - latents[:, :-1, :]
+    return torch.mean(diff.pow(2))

--- a/signstream/models/rvq/decoder.py
+++ b/signstream/models/rvq/decoder.py
@@ -5,21 +5,48 @@ from .encoder import PART_TYPES
 
 
 class PoseDecoder(nn.Module):
-    """Mirror of :class:`PoseEncoder` to reconstruct pose chunks."""
+    """Decoder matching :class:`PoseEncoder` architecture."""
 
-    def __init__(self, latent_dim: int, output_dim: int) -> None:
+    def __init__(
+        self,
+        latent_dim: int,
+        frame_dim: int,
+        chunk_len: int,
+        arch: str = "mlp",
+    ) -> None:
         super().__init__()
-        self.net = nn.Sequential(
-            nn.Linear(latent_dim, latent_dim),
-            nn.ReLU(),
-            nn.Linear(latent_dim, output_dim),
-        )
+        self.arch = arch
+        self.chunk_len = chunk_len
+        self.frame_dim = frame_dim
+        if arch == "mlp":
+            self.net = nn.Sequential(
+                nn.Linear(latent_dim, latent_dim),
+                nn.ReLU(),
+                nn.Linear(latent_dim, frame_dim * chunk_len),
+            )
+        elif arch == "transformer":
+            self.pos_embed = nn.Parameter(torch.zeros(chunk_len, latent_dim))
+            encoder_layer = nn.TransformerEncoderLayer(
+                d_model=latent_dim, nhead=4, batch_first=True
+            )
+            self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=2)
+            self.output_proj = nn.Linear(latent_dim, frame_dim)
+        else:
+            raise ValueError(f"Unknown arch: {arch}")
         self.type_embed = nn.Embedding(len(PART_TYPES), latent_dim)
 
     def forward(self, z: torch.Tensor, part: str) -> torch.Tensor:
         part_id = torch.full(
             (z.shape[0],), PART_TYPES[part], dtype=torch.long, device=z.device
         )
-        h = z + self.type_embed(part_id)
-        out = self.net(h)
-        return out
+        if self.arch == "mlp":
+            h = z + self.type_embed(part_id)
+            out = self.net(h)
+            return out.view(z.shape[0], self.chunk_len, self.frame_dim)
+        else:
+            h = z.unsqueeze(1).expand(-1, self.chunk_len, -1)
+            h = h + self.pos_embed.unsqueeze(0)
+            h = h + self.type_embed(part_id).unsqueeze(1)
+            h = self.transformer(h)
+            out = self.output_proj(h)
+            return out

--- a/signstream/models/rvq/decoder.py
+++ b/signstream/models/rvq/decoder.py
@@ -1,0 +1,25 @@
+import torch
+from torch import nn
+from typing import Dict
+from .encoder import PART_TYPES
+
+
+class PoseDecoder(nn.Module):
+    """Mirror of :class:`PoseEncoder` to reconstruct pose chunks."""
+
+    def __init__(self, latent_dim: int, output_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(latent_dim, latent_dim),
+            nn.ReLU(),
+            nn.Linear(latent_dim, output_dim),
+        )
+        self.type_embed = nn.Embedding(len(PART_TYPES), latent_dim)
+
+    def forward(self, z: torch.Tensor, part: str) -> torch.Tensor:
+        part_id = torch.full(
+            (z.shape[0],), PART_TYPES[part], dtype=torch.long, device=z.device
+        )
+        h = z + self.type_embed(part_id)
+        out = self.net(h)
+        return out

--- a/signstream/models/rvq/encoder.py
+++ b/signstream/models/rvq/encoder.py
@@ -1,0 +1,37 @@
+import torch
+from torch import nn
+from typing import Dict
+
+PART_TYPES: Dict[str, int] = {
+    "face": 0,
+    "left_hand": 1,
+    "right_hand": 2,
+    "body": 3,
+    "full_body": 4,
+}
+
+
+class PoseEncoder(nn.Module):
+    """Simple MLP encoder for pose chunks.
+
+    The encoder flattens the spatio-temporal pose representation and
+    projects it into a latent space. A learnable embedding is added to
+    distinguish different body parts.
+    """
+
+    def __init__(self, input_dim: int, latent_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, latent_dim),
+            nn.ReLU(),
+            nn.Linear(latent_dim, latent_dim),
+        )
+        self.type_embed = nn.Embedding(len(PART_TYPES), latent_dim)
+
+    def forward(self, x: torch.Tensor, part: str) -> torch.Tensor:
+        part_id = torch.full(
+            (x.shape[0],), PART_TYPES[part], dtype=torch.long, device=x.device
+        )
+        h = self.net(x)
+        h = h + self.type_embed(part_id)
+        return h

--- a/signstream/models/rvq/quantizer.py
+++ b/signstream/models/rvq/quantizer.py
@@ -22,6 +22,7 @@ class ResidualVectorQuantizer(nn.Module):
         super().__init__()
         self.levels = levels
         self.beta = commitment_beta
+        self.codebook_size = codebook_size
         self.codebooks = nn.ModuleList(
             [nn.Embedding(codebook_size, dim) for _ in range(levels)]
         )
@@ -30,8 +31,8 @@ class ResidualVectorQuantizer(nn.Module):
 
     def _quantize(
         self, x: torch.Tensor, emb: nn.Embedding
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Quantize ``x`` with the given codebook.
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize ``x`` with the given codebook and return soft usage probs.
 
         Args:
             x: Tensor of shape ``[..., dim]`` to quantize.
@@ -40,19 +41,22 @@ class ResidualVectorQuantizer(nn.Module):
         Returns:
             quantized: Quantized tensor with same shape as ``x``.
             indices: Indices of selected codewords with shape ``[...]``.
+            probs: Softmax probabilities over the codebook (for usage reg).
         """
-        # Compute squared L2 distance to codebook entries.
         distances = (
             x.pow(2).sum(dim=-1, keepdim=True)
             - 2 * torch.matmul(x, emb.weight.t())
             + emb.weight.pow(2).sum(dim=-1)
-        )  # (..., codebook_size)
-        indices = distances.argmin(dim=-1)  # (...)
+        )
+        probs = torch.softmax(-distances, dim=-1)
+        indices = distances.argmin(dim=-1)
         quantized = emb(indices)
-        return quantized, indices
+        return quantized, indices, probs
 
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Quantize ``x``.
+    def forward(
+        self, x: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize ``x`` and compute usage regularization.
 
         Args:
             x: Input tensor of shape ``[N, D]``.
@@ -60,18 +64,28 @@ class ResidualVectorQuantizer(nn.Module):
         Returns:
             quantized: Quantized representation with same shape as ``x``.
             codes: Tensor of shape ``[N, levels]`` containing code indices.
-            loss: Commitment loss term.
+            commit_loss: Commitment loss term.
+            usage_loss: KL divergence to uniform over codebook usage.
         """
         residual = x
         quantized_sum = torch.zeros_like(x)
         codes = []
-        loss = 0.0
+        commit_loss = 0.0
+        usage_loss = 0.0
         for emb in self.codebooks:
-            quantized, idx = self._quantize(residual, emb)
+            quantized, idx, probs = self._quantize(residual, emb)
             quantized_sum = quantized_sum + quantized
             codes.append(idx)
-            loss = loss + torch.mean((residual.detach() - quantized) ** 2)
-            loss = loss + self.beta * torch.mean((residual - quantized.detach()) ** 2)
+            commit_loss = commit_loss + torch.mean((residual.detach() - quantized) ** 2)
+            commit_loss = commit_loss + self.beta * torch.mean((residual - quantized.detach()) ** 2)
+            usage_loss = usage_loss + (
+                probs * (probs * emb.num_embeddings).clamp(min=1e-8).log()
+            ).sum(dim=-1).mean()
             residual = residual - quantized
         codes = torch.stack(codes, dim=-1)
-        return quantized_sum + (residual - residual.detach()), codes, loss
+        return (
+            quantized_sum + (residual - residual.detach()),
+            codes,
+            commit_loss,
+            usage_loss,
+        )

--- a/signstream/models/rvq/quantizer.py
+++ b/signstream/models/rvq/quantizer.py
@@ -1,0 +1,77 @@
+import torch
+from torch import nn
+from typing import Tuple
+
+class ResidualVectorQuantizer(nn.Module):
+    """Residual vector quantizer with straight-through estimator.
+
+    This module implements a simple multi-level residual vector
+    quantization scheme. For an input ``x`` it sequentially quantizes
+    the residual using ``levels`` codebooks. The quantized vectors are
+    summed to form the final representation and the indices of the
+    selected codewords are returned.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        codebook_size: int,
+        levels: int = 2,
+        commitment_beta: float = 0.25,
+    ) -> None:
+        super().__init__()
+        self.levels = levels
+        self.beta = commitment_beta
+        self.codebooks = nn.ModuleList(
+            [nn.Embedding(codebook_size, dim) for _ in range(levels)]
+        )
+        for emb in self.codebooks:
+            nn.init.uniform_(emb.weight, -1.0 / codebook_size, 1.0 / codebook_size)
+
+    def _quantize(
+        self, x: torch.Tensor, emb: nn.Embedding
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize ``x`` with the given codebook.
+
+        Args:
+            x: Tensor of shape ``[..., dim]`` to quantize.
+            emb: Codebook embedding.
+
+        Returns:
+            quantized: Quantized tensor with same shape as ``x``.
+            indices: Indices of selected codewords with shape ``[...]``.
+        """
+        # Compute squared L2 distance to codebook entries.
+        distances = (
+            x.pow(2).sum(dim=-1, keepdim=True)
+            - 2 * torch.matmul(x, emb.weight.t())
+            + emb.weight.pow(2).sum(dim=-1)
+        )  # (..., codebook_size)
+        indices = distances.argmin(dim=-1)  # (...)
+        quantized = emb(indices)
+        return quantized, indices
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize ``x``.
+
+        Args:
+            x: Input tensor of shape ``[N, D]``.
+
+        Returns:
+            quantized: Quantized representation with same shape as ``x``.
+            codes: Tensor of shape ``[N, levels]`` containing code indices.
+            loss: Commitment loss term.
+        """
+        residual = x
+        quantized_sum = torch.zeros_like(x)
+        codes = []
+        loss = 0.0
+        for emb in self.codebooks:
+            quantized, idx = self._quantize(residual, emb)
+            quantized_sum = quantized_sum + quantized
+            codes.append(idx)
+            loss = loss + torch.mean((residual.detach() - quantized) ** 2)
+            loss = loss + self.beta * torch.mean((residual - quantized.detach()) ** 2)
+            residual = residual - quantized
+        codes = torch.stack(codes, dim=-1)
+        return quantized_sum + (residual - residual.detach()), codes, loss

--- a/signstream/models/rvq/rvq_model.py
+++ b/signstream/models/rvq/rvq_model.py
@@ -1,0 +1,34 @@
+import torch
+from torch import nn
+from .encoder import PoseEncoder
+from .decoder import PoseDecoder
+from .quantizer import ResidualVectorQuantizer
+
+
+class RVQModel(nn.Module):
+    """Encoder -> Residual VQ -> Decoder pipeline."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        latent_dim: int,
+        codebook_size: int,
+        levels: int,
+        commitment_beta: float = 0.25,
+    ) -> None:
+        super().__init__()
+        self.encoder = PoseEncoder(input_dim, latent_dim)
+        self.quantizer = ResidualVectorQuantizer(
+            dim=latent_dim,
+            codebook_size=codebook_size,
+            levels=levels,
+            commitment_beta=commitment_beta,
+        )
+        self.decoder = PoseDecoder(latent_dim, input_dim)
+
+    def forward(self, x: torch.Tensor, part: str):
+        """Encode, quantize and decode pose chunks."""
+        z = self.encoder(x, part)
+        z_q, codes, q_loss = self.quantizer(z)
+        recon = self.decoder(z_q, part)
+        return recon, codes, q_loss

--- a/signstream/tests/test_dataset.py
+++ b/signstream/tests/test_dataset.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import json
+import numpy as np
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from signstream.data.datasets import CSLDailyDataset
+
+
+def _create_dummy_dataset(root: Path) -> None:
+    (root / "frames_512x512").mkdir(parents=True)
+    data = np.zeros((20, 134, 3), dtype=np.float32)
+    np.save(root / "frames_512x512" / "sample.npy", data)
+    annotations = {
+        "sample": {"text": "hi", "gloss": "hi", "num_frames": 20, "signer": 0}
+    }
+    with open(root / "annotations.json", "w", encoding="utf-8") as f:
+        json.dump(annotations, f)
+    split = {"train": ["sample"], "val": [], "test": []}
+    with open(root / "split_files.json", "w", encoding="utf-8") as f:
+        json.dump(split, f)
+
+
+def test_dataset_chunking(tmp_path) -> None:
+    _create_dummy_dataset(tmp_path)
+    ds = CSLDailyDataset(root_dir=str(tmp_path), split="train", chunk_len=10, fps=30)
+    sample = ds[0]
+    assert sample["chunks"]["full_body"].shape[0] == 2
+    from signstream.data.datasets import CSLDailyDataModule
+
+    loader = torch.utils.data.DataLoader(
+        ds, batch_size=1, collate_fn=CSLDailyDataModule.collate_fn
+    )
+    batch = next(iter(loader))
+    assert batch["chunks"]["full_body"].shape[0] == 1

--- a/signstream/tests/test_export.py
+++ b/signstream/tests/test_export.py
@@ -28,7 +28,8 @@ def test_export_tokens(tmp_path) -> None:
     start, end = ds.body_part_indices["full_body"]
     num_points = end - start + 1
     model = RVQModel(
-        input_dim=5 * num_points * 3,
+        frame_dim=num_points * 3,
+        chunk_len=5,
         latent_dim=16,
         codebook_size=8,
         levels=2,

--- a/signstream/tests/test_export.py
+++ b/signstream/tests/test_export.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import json
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from signstream.data.datasets import CSLDailyDataset
+from signstream.models.rvq.rvq_model import RVQModel
+from signstream.inference.export_tokens import export_samples
+
+
+def _create_dummy_dataset(root: Path) -> None:
+    (root / "frames_512x512").mkdir(parents=True)
+    data = np.zeros((10, 134, 3), dtype=np.float32)
+    np.save(root / "frames_512x512" / "sample.npy", data)
+    annotations = {"sample": {"text": "hi", "gloss": "hi", "num_frames": 10, "signer": 0}}
+    with open(root / "annotations.json", "w", encoding="utf-8") as f:
+        json.dump(annotations, f)
+    split = {"train": ["sample"], "val": [], "test": []}
+    with open(root / "split_files.json", "w", encoding="utf-8") as f:
+        json.dump(split, f)
+
+
+def test_export_tokens(tmp_path) -> None:
+    _create_dummy_dataset(tmp_path)
+    ds = CSLDailyDataset(root_dir=str(tmp_path), split="train", chunk_len=5, fps=30)
+    start, end = ds.body_part_indices["full_body"]
+    num_points = end - start + 1
+    model = RVQModel(
+        input_dim=5 * num_points * 3,
+        latent_dim=16,
+        codebook_size=8,
+        levels=2,
+    )
+    samples = export_samples(model, ds, num_samples=1, enable_rle=False)
+    assert len(samples) == 1
+    assert "tokens" in samples[0]

--- a/signstream/tests/test_quantizer.py
+++ b/signstream/tests/test_quantizer.py
@@ -10,7 +10,8 @@ from signstream.models.rvq.quantizer import ResidualVectorQuantizer
 def test_quantizer_roundtrip() -> None:
     quant = ResidualVectorQuantizer(dim=8, codebook_size=16, levels=2)
     x = torch.randn(4, 8)
-    q, codes, loss = quant(x)
+    q, codes, c_loss, u_loss = quant(x)
     assert q.shape == x.shape
     assert codes.shape == (4, 2)
-    assert loss.shape == torch.Size([])
+    assert c_loss.shape == torch.Size([])
+    assert u_loss.shape == torch.Size([])

--- a/signstream/tests/test_quantizer.py
+++ b/signstream/tests/test_quantizer.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from signstream.models.rvq.quantizer import ResidualVectorQuantizer
+
+
+def test_quantizer_roundtrip() -> None:
+    quant = ResidualVectorQuantizer(dim=8, codebook_size=16, levels=2)
+    x = torch.randn(4, 8)
+    q, codes, loss = quant(x)
+    assert q.shape == x.shape
+    assert codes.shape == (4, 2)
+    assert loss.shape == torch.Size([])

--- a/signstream/training/losses.py
+++ b/signstream/training/losses.py
@@ -1,0 +1,26 @@
+"""Loss utilities for RVQ training."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+import torch.nn.functional as F
+
+from signstream.models.metrics.temporal import temporal_loss as _temporal_loss
+
+
+def recon_loss(pred: Tensor, target: Tensor, loss_type: str = "huber") -> Tensor:
+    """Reconstruction loss using Huber or MSE."""
+    if loss_type == "huber":
+        return F.smooth_l1_loss(pred, target)
+    return F.mse_loss(pred, target)
+
+
+def temporal_loss(latents: Tensor) -> Tensor:
+    """Wrapper for temporal smoothness loss."""
+    return _temporal_loss(latents)
+
+
+def usage_regularization(prob_loss: Tensor, weight: float) -> Tensor:
+    """Apply weighting to codebook usage regularization."""
+    return weight * prob_loss

--- a/signstream/training/train_rvq.py
+++ b/signstream/training/train_rvq.py
@@ -1,0 +1,81 @@
+import argparse
+import yaml
+import torch
+from torch.utils.data import DataLoader
+import torch.nn.functional as F
+
+from signstream.data.datasets import CSLDailyDataset
+from signstream.models.rvq.rvq_model import RVQModel
+from signstream.training.seed import set_seed
+
+
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def train(config: dict) -> None:
+    set_seed(config["train"]["seed"])
+
+    dataset = CSLDailyDataset(
+        root_dir=config["data"]["root"],
+        split=config["data"].get("split", "train"),
+        chunk_len=config["data"]["chunk_len"],
+        fps=config["data"]["fps"],
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=config["train"]["batch_size"],
+        shuffle=True,
+    )
+
+    part = "full_body"
+    start, end = dataset.body_part_indices[part]
+    num_points = end - start + 1
+    input_dim = config["data"]["chunk_len"] * num_points * 3
+
+    model = RVQModel(
+        input_dim=input_dim,
+        latent_dim=config["model"]["latent_dim"],
+        codebook_size=config["model"]["rvq"]["codebook_size"],
+        levels=config["model"]["rvq"]["levels"],
+        commitment_beta=config["model"]["rvq"].get("commitment_beta", 0.25),
+    )
+
+    device = torch.device(config["train"].get("device", "cpu"))
+    model.to(device)
+
+    optimizer = torch.optim.Adam(
+        model.parameters(),
+        lr=config["train"]["lr"],
+        weight_decay=config["train"]["wd"],
+    )
+
+    epochs = config["train"]["epochs"]
+    for epoch in range(epochs):
+        for batch in dataloader:
+            x = batch["chunks"][part]  # [B, N, L, K, 3]
+            B, N, L, K, C = x.shape
+            x_flat = x.view(B * N, L * K * C).to(device)
+            recon, codes, q_loss = model(x_flat, part)
+            recon = recon.view(B * N, L, K, C)
+            loss_recon = F.mse_loss(recon, x.to(device))
+            loss = loss_recon + q_loss
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        print(f"epoch {epoch+1} loss {loss.item():.4f}")
+
+    torch.save({"model_state": model.state_dict()}, "rvq_model.pt")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train RVQ model")
+    parser.add_argument("--config", type=str, default="configs/default.yaml")
+    args = parser.parse_args()
+    config = load_config(args.config)
+    train(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/signstream/training/train_rvq.py
+++ b/signstream/training/train_rvq.py
@@ -1,12 +1,17 @@
 import argparse
+import random
+import yaml
+import argparse
+import argparse
+import random
 import yaml
 import torch
 from torch.utils.data import DataLoader
-import torch.nn.functional as F
 
 from signstream.data.datasets import CSLDailyDataset
 from signstream.models.rvq.rvq_model import RVQModel
 from signstream.training.seed import set_seed
+from signstream.training.losses import recon_loss, temporal_loss, usage_regularization
 
 
 def load_config(path: str) -> dict:
@@ -32,14 +37,16 @@ def train(config: dict) -> None:
     part = "full_body"
     start, end = dataset.body_part_indices[part]
     num_points = end - start + 1
-    input_dim = config["data"]["chunk_len"] * num_points * 3
+    frame_dim = num_points * 3
 
     model = RVQModel(
-        input_dim=input_dim,
+        frame_dim=frame_dim,
+        chunk_len=config["data"]["chunk_len"],
         latent_dim=config["model"]["latent_dim"],
         codebook_size=config["model"]["rvq"]["codebook_size"],
         levels=config["model"]["rvq"]["levels"],
         commitment_beta=config["model"]["rvq"].get("commitment_beta", 0.25),
+        arch=config["model"].get("arch", "mlp"),
     )
 
     device = torch.device(config["train"].get("device", "cpu"))
@@ -52,21 +59,48 @@ def train(config: dict) -> None:
     )
 
     epochs = config["train"]["epochs"]
+    usage_coeff = config["model"]["rvq"].get("usage_beta", 0.0)
+    temporal_alpha = config["train"].get("temporal_alpha", 0.0)
+
+    best_loss = float("inf")
+    code_usage = [set() for _ in range(config["model"]["rvq"]["levels"])]
+
     for epoch in range(epochs):
+        epoch_loss = 0.0
         for batch in dataloader:
             x = batch["chunks"][part]  # [B, N, L, K, 3]
             B, N, L, K, C = x.shape
-            x_flat = x.view(B * N, L * K * C).to(device)
-            recon, codes, q_loss = model(x_flat, part)
-            recon = recon.view(B * N, L, K, C)
-            loss_recon = F.mse_loss(recon, x.to(device))
-            loss = loss_recon + q_loss
+            x_seq = x.view(B * N, L, K * C).to(device)
+            recon, codes, q_loss, usage_loss, z_q = model(x_seq, part)
+            loss_r = recon_loss(recon, x_seq, loss_type="huber")
+            z_q_seq = z_q.view(B, N, -1)
+            loss_t = temporal_loss(z_q_seq) if N > 1 else torch.tensor(0.0, device=device)
+            loss = loss_r + q_loss + usage_regularization(usage_loss, usage_coeff) + temporal_alpha * loss_t
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
-        print(f"epoch {epoch+1} loss {loss.item():.4f}")
+            epoch_loss += loss.item()
+            for lvl in range(codes.shape[1]):
+                code_usage[lvl].update(codes[:, lvl].detach().cpu().tolist())
+        avg_loss = epoch_loss / len(dataloader)
+        print(f"epoch {epoch+1} loss {avg_loss:.4f}")
+        if avg_loss < best_loss:
+            best_loss = avg_loss
+            torch.save({"model_state": model.state_dict()}, "rvq_model_best.pt")
 
-    torch.save({"model_state": model.state_dict()}, "rvq_model.pt")
+    # Codebook utilization
+    for lvl, used in enumerate(code_usage):
+        util = len(used) / config["model"]["rvq"]["codebook_size"]
+        print(f"level {lvl} utilization: {util:.2%}")
+
+    # Sample a training video and log tokens
+    sample = dataset[random.randrange(len(dataset))]
+    x = sample["chunks"][part]
+    N, L, K, C = x.shape
+    x_seq = x.view(N, L, K * C).to(device)
+    with torch.no_grad():
+        _, codes, _, _, _ = model(x_seq, part)
+    print("sample tokens:", codes.tolist())
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add encoder, decoder, residual vector quantizer and RVQ model
- provide training script and token export with optional run-length encoding
- fix dataset normalization and add simple unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbcb32faec832c92c382184e534353